### PR TITLE
Importing whole intrachromosomal matrices

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparseHiC
 Type: Package
 Title: Efficient compression and analysis of Hi-C Data
-Version: 0.4.2
+Version: 0.4.3
 Date: 2017-01-02
 Authors@R: c(
     person("Caleb", "Lareau", email = "caleblareau@g.harvard.edu", role = c("aut", "cre")),

--- a/R/coreCompress.R
+++ b/R/coreCompress.R
@@ -60,6 +60,34 @@ NULL
     
 }
 
+# Computes pairwise (faster and less memory)
+.matrixBuild.intra2 <- function(chr, bed.GRanges, dat.long, res, dist, n){
+    options(scipen=999)
+    cur.chrom <- bed.GRanges[seqnames(bed.GRanges) == chr]
+    vals <-  mcols(cur.chrom)$region
+    dat.chrom <- dat.long[dat.long$idx1 %in% vals & dat.long$idx2 %in% vals, ]
+    if( n > 0 ){
+        dat.chrom$region[abs(dat.chrom$idx1 - dat.chrom$idx2) > n] <- 0
+    }
+    cur.chrom$matIdx <- seq_along(cur.chrom)
+    matIdx <- cur.chrom$matIdx
+    names( matIdx ) <- cur.chrom$region
+    dat.chrom$matIdx1 <- matIdx[as.character( dat.chrom$idx1 )]
+    dat.chrom$matIdx2 <- matIdx[as.character( dat.chrom$idx2 )]
+    numBins <- length( cur.chrom )
+    matr <- matrix( 0, nrow=numBins, ncol=numBins )
+    for( j in seq_len( numBins ) ){
+        ww <- dat.chrom$matIdx1 == j
+        if( sum( ww ) > 0 ){
+            matr[j,dat.chrom$matIdx2[ww]] <- dat.chrom$region[ww]
+        }
+    }
+    rownames(matr) <- start( cur.chrom )
+    colnames(matr) <- start( cur.chrom )
+    matr
+}
+
+
 # Modification of function above to do two chromosomes instead of just one
 .matrixBuild.inter <- function(chr1, chr2, bed.GRanges, dat.long, res, dist){
     options(scipen=999)


### PR DESCRIPTION
Fixed the following bug: When setting n=0 in import.HiCPro, only the diagonal was stored, instead of the whole matrix, as the documentation said. I also wrote an alternative to .matrixBuild.intra that uses less RAM (allows importing high resolution data) and it is a bit faster.